### PR TITLE
Adjust Meteor policy filename links

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -9,4 +9,4 @@
 - [ ] An overview of the suggested solution
 - [ ] If the feature changes current behavior, reasons why your solution is better
 
-See [here](https://github.com/meteor/meteor/blob/devel/Contributing.md#feature-requests) for more detail on what is expected of a feature request.
+See [here](https://github.com/meteor/meteor/blob/devel/CONTRIBUTING.md#feature-requests) for more detail on what is expected of a feature request.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository is used to track [Meteor](https://github.com/meteor/meteor) feature requests only (requests for new Meteor functionality). Click [here](https://github.com/meteor/meteor-feature-requests/issues/new) to open a new feature request.
 
-**Note:** Meteor bugs are tracked in the [Meteor repo issue tracker](https://github.com/meteor/meteor/issues). 
+**Note:** Meteor bugs are tracked in the [Meteor repo issue tracker](https://github.com/meteor/meteor/issues).
 
 ## Guidelines
 
@@ -19,6 +19,6 @@ Finally, you can show your support for (or against!) features by using GitHub re
 ## Resources
 
 - Main Meteor repo: https://github.com/meteor/meteor
-- Contribution guidelines: https://github.com/meteor/meteor/blob/devel/Contributing.md
-- Feature request triaging guidelines: https://github.com/meteor/meteor/blob/devel/IssueTriage.md#feature-requests
-- Feature request (PR) development guide: https://github.com/meteor/meteor/blob/devel/Development.md
+- Contribution guidelines: https://github.com/meteor/meteor/blob/devel/CONTRIBUTING.md
+- Feature request triaging guidelines: https://github.com/meteor/meteor/blob/devel/ISSUE_TRIAGE.md#feature-requests
+- Feature request (PR) development guide: https://github.com/meteor/meteor/blob/devel/DEVELOPMENT.md


### PR DESCRIPTION
The main Meteor repo policy filenames are changing - see meteor/meteor#9207. After that PR has been merged, this PR should also be merged.